### PR TITLE
翻译取消flows的章节

### DIFF
--- a/docs/best/actions.md
+++ b/docs/best/actions.md
@@ -199,3 +199,7 @@ class Store {
 	})
 }
 ```
+
+#### Flows可以取消
+
+Flow是可以取消的，这意味着您可以在返回的promise上调用`cancel()`。 这将立即停止生成器，但仍将处理任何finally子句。 返回的promise自身将拒绝其消息为`FLOW_CANCELLED`的`FlowCancellationError`实例（此错误从程序包中导出）。 还导出了一个`isFlowCancellationError(error)`的helper，当且仅当提供的参数是`FlowCancellationError`时，该方法才返回true。


### PR DESCRIPTION
翻译的[原文](https://mobx.js.org/best/actions.html#flows-can-be-cancelled)片段如下：

> #### Flows can be cancelled
>
> Flows are cancellable, that means that you can call `cancel()` on the returned promise. This will stop the generator immediately, but any finally clause will still be processed. The returned promise itself will reject with an instance of `FlowCancellationError` (this error is exported from the package) whose message is `FLOW_CANCELLED`. Also exported is a `isFlowCancellationError(error)` helper that returns true if and only if the provided argument is a `FlowCancellationError`.

